### PR TITLE
fix: Ignore `Process` key

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -225,6 +225,7 @@ Deno.test("stringify()", async (t) => {
   await t.step("invalid keys", async (t) => {
     await t.step("unrecognized keys", () => {
       assertStrictEquals(stringify({ key: "Unidentified" }), "");
+      assertStrictEquals(stringify({ key: "Process" }), "");
       assertStrictEquals(stringify({ key: "Dead" }), "");
     });
 

--- a/mod.ts
+++ b/mod.ts
@@ -124,7 +124,7 @@ const specialCases = {
 };
 
 const ignored =
-  /^($|Unidentified$|Dead$|Alt|Control|Hyper|Meta|Shift|Super|OS)/;
+  /^($|Unidentified$|Process$|Dead$|Alt|Control|Hyper|Meta|Shift|Super|OS)/;
 
 /**
  * Converts a Key event into a string representation.


### PR DESCRIPTION
close [✅️Processを無視する (vim-like-key-notation)](https://scrapbox.io/takker/✅️Processを無視する_(vim-like-key-notation))